### PR TITLE
Parse_patiens and parse_profesionals fix

### DIFF
--- a/lib/drivers/base_driver.rb
+++ b/lib/drivers/base_driver.rb
@@ -8,16 +8,34 @@ module Drivers
       method_name = "parse_#{request_type}"
       public_send(method_name, request)
     end
-    #Método que deben tener todos los drivers. Permite reciclar JSON de consulta
+
+    # Método que deben tener todos los drivers. Permite reciclar JSON de consulta
     def professionals_key_converter(request) end
+
     def parse_patients(request) end
+
     def parse_professionals(request) end
+
     def parse_consults(request) end
+
     def parse_movements(request) end
-    def parse_unknown(request)
+
+    def parse_unknown(_request)
       {}.to_json
     end
-      
+
+    def check_request(request, attr_list)
+      return false unless check_param(request)
+      return false unless check_param(attr_list)
+      attr_list.each do |attribute|
+        return false unless request.key?(attribute)
+      end
+      true
+    end
+
+    def check_param(attribute)
+      return false if attribute.nil? || attribute.empty?
+      attribute
     end
   end
 end

--- a/lib/drivers/base_driver.rb
+++ b/lib/drivers/base_driver.rb
@@ -8,5 +8,7 @@ module Drivers
       method_name = "parse_#{request_type}"
       public_send(method_name, request)
     end
+    #Método que deben tener todos los drivers. Permite reciclar JSON de consulta
+    def professionals_key_converter(request) end
   end
 end

--- a/lib/drivers/base_driver.rb
+++ b/lib/drivers/base_driver.rb
@@ -10,5 +10,14 @@ module Drivers
     end
     #Método que deben tener todos los drivers. Permite reciclar JSON de consulta
     def professionals_key_converter(request) end
+    def parse_patients(request) end
+    def parse_professionals(request) end
+    def parse_consults(request) end
+    def parse_movements(request) end
+    def parse_unknown(request)
+      {}.to_json
+    end
+      
+    end
   end
 end

--- a/lib/drivers/base_driver.rb
+++ b/lib/drivers/base_driver.rb
@@ -18,7 +18,12 @@ module Drivers
 
     def parse_consults(request) end
 
-    def parse_movements(request) end
+    def parse_movements(request)
+      keys = %w[tipo runPaciente runProfesional detalles]
+      request_type = check_movement(request, keys)
+      method_name = "parse_#{request_type}s"
+      public_send(method_name, request)
+    end
 
     def parse_unknown(_request)
       {}.to_json
@@ -37,5 +42,7 @@ module Drivers
       return false if attribute.nil? || attribute.empty?
       attribute
     end
+
+    
   end
 end

--- a/lib/drivers/centers/medical_center1.rb
+++ b/lib/drivers/centers/medical_center1.rb
@@ -25,12 +25,12 @@ module Drivers
       return {}.to_json unless check_request(request, %w[nombre run edad])
       nombre = request['nombre'].split(' ', 2)
       { 'rut' => request['run'][0..-2] + '-' + request['run'][-1],
-        'name' => nombre[0],
         'last_name' => nombre[1],
+        'name' => nombre[0],
         'age' => request['edad'] }.to_json
     end
 
-    def parse_professionals(request)
+    def parse_professional(request)
       request.merge(key_converter(request)).slice!(
         :especialidad, :numero_registro,
         :fecha_registro, :run, :nombre,
@@ -40,7 +40,7 @@ module Drivers
 
     def parse_consults(request)
       keys = %w[runPaciente runProfesional fecha razon sintoma observaciones]
-      return {}.to_json unless check_request(request  , keys)
+      return {}.to_json unless check_request(request, keys)
       { 'patient_rut' => request['runPaciente'][0..-2] + '-' +
         request['runPaciente'][-1],
         'professional_rut' => request['runProfesional'][0..-2] + '-' +
@@ -48,22 +48,60 @@ module Drivers
         'date' => request['fecha'],
         'reason' => request['razon'],
         'symptoms' => request['sintoma'],
-        'observations' => request['observaciones']}.to_json
+        'observations' => request['observaciones'] }.to_json
     end
 
-    def parse_movements(request)
-      keys = %w[tipo runPaciente runProfesional detalles]
-      return {}.to_json unless check_request(request, keys)
-      { 'type' => request['tipo'],
-        'patient_rut' => request['runPaciente'][0..-2] + '-' +
-          request['runPaciente'][-1],
-        'professional_rut' => request['runProfesional'][0..-2] + '-' +
-          request['runProfesional'][-1],
-        'detail' => request['detalles']}.to_json
+    def check_movement(request, attr_required)
+      attr_required.each do |atribute|
+        return 'unknown' unless request.include?(atribute)
+        return 'unknown' if request[atribute].nil?
+      end
+      request['tipo'].downcase!
     end
-    
-    def parse_exam(request)
-      return {}.to_json unless check_request()
+
+    def parse_exams(request)
+      {
+        'type' => 'exam',
+        'patient' => request['runPaciente'],
+        'professional' => request['runProfesional'],
+        'details' => request['detalles']
+      }
+    end
+
+    def parse_diagnostics(request)
+      {
+        'type' => 'diagnostic',
+        'patient' => request['runPaciente'],
+        'professional' => request['runProfesional'],
+        'details' => request['detalles']
+      }
+    end
+
+    def parse_prescriptions(request)
+      {
+        'type' => 'prescription',
+        'patient' => request['runPaciente'],
+        'professional' => request['runProfesional'],
+        'details' => request['detalles']
+      }
+    end
+
+    def parse_licenses(request)
+      {
+        'type' => 'license',
+        'patient' => request['runPaciente'],
+        'professional' => request['runProfesional'],
+        'details' => request['detalles']
+      }
+    end
+
+    def parse_procedures(request)
+      {
+        'type' => 'procedures',
+        'patient' => request['runPaciente'],
+        'professional' => request['runProfesional'],
+        'details' => request['detalles']
+      }
     end
   end
 end

--- a/lib/drivers/centers/medical_center1.rb
+++ b/lib/drivers/centers/medical_center1.rb
@@ -2,31 +2,35 @@ module Drivers
   # Driver for Medical Center 1
   # This parse the request to a normalized json-like hash
   class MedicalCenter1 < BaseDriver
+    def professionals_data_parser(request)
+      { 'speciality' => request['especialidad'],
+        'registration_number' => request['numero_registro'],
+        'registration_date' => request['fecha_registro'],
+        'rut' => request['run'][0..-2] + '-' + request['run'][-1],
+        'name' => request['nombre'],
+        'last_name' => request['apellido'],
+        'age' => request['edad'],
+        'nationality' => request['nacionalidad'],
+        'phone' => request['telefono'] }
+    end
+
     def professionals_key_converter(request)
-      return {}.to_json unless request.empty?
-    { 'speciality' => request['especialidad'],
-      'registration_number' => request['numero_registro'],
-      'registration_date' => request['fecha_registro'],  
-      'rut' => request['run'][0..-2] + '-' + request['run'][-1],
-      'name' => request['nombre'],
-      'last_name' => request['apellido'],
-      'age' => request['edad'],
-      'nationality' => request['nacionalidad'],
-      'phone' => request['telefono']
-    }
+      params = %w[especialidad numero_registro fecha_registro run nombre
+                  apellido edad nacionalidad telefono]
+      return {}.to_json unless check_request(request, params)
+      professionals_data_parser(request).to_json()
     end
 
     def parse_patients(request)
-      return {}.to_json unless request.empty?
+      return {}.to_json unless check_request(request, %w[nombre run edad])
       nombre = request['nombre'].split(' ', 2)
       { 'rut' => request['run'][0..-2] + '-' + request['run'][-1],
         'name' => nombre[0],
-        'last_name' => nombre[1], 
-        'age' => request['edad']}.to_json
+        'last_name' => nombre[1],
+        'age' => request['edad'] }.to_json
     end
 
     def parse_professionals(request)
-      return {}.to_json unless request.empty?
       request.merge(key_converter(request)).slice!(
         :especialidad, :numero_registro,
         :fecha_registro, :run, :nombre,
@@ -35,24 +39,31 @@ module Drivers
     end
 
     def parse_consults(request)
-      return {}.to_json unless request.empty?
-      {
-      'patient_rut' => request['runPaciente'][0..-2] + '-' + request['runPaciente'][-1],
-      'professional_rut' => request['runProfesional'][0..-2] + '-' + request['runProfesional'][-1],
-      'date' => request['fecha'],
-      'reason' => request['razon'],
-      'symptoms' => request['sintoma'],
-      'observations' = request['observaciones']}.to_json
+      keys = %w[runPaciente runProfesional fecha razon sintoma observaciones]
+      return {}.to_json unless check_request(request  , keys)
+      { 'patient_rut' => request['runPaciente'][0..-2] + '-' +
+        request['runPaciente'][-1],
+        'professional_rut' => request['runProfesional'][0..-2] + '-' +
+          request['runProfesional'][-1],
+        'date' => request['fecha'],
+        'reason' => request['razon'],
+        'symptoms' => request['sintoma'],
+        'observations' => request['observaciones']}.to_json
     end
 
     def parse_movements(request)
-      return {}.to_json unless request.empty?
-      {
-      'type' => request['tipo'],
-      'patient_rut' => request['runPaciente'][0..-2] + '-' + request['runPaciente'][-1],
-      'professional_rut' => request['runProfesional'][0..-2] + '-' + request['runProfesional'][-1],
-      'detail' =>request['detalles']}.to_json
+      keys = %w[tipo runPaciente runProfesional detalles]
+      return {}.to_json unless check_request(request, keys)
+      { 'type' => request['tipo'],
+        'patient_rut' => request['runPaciente'][0..-2] + '-' +
+          request['runPaciente'][-1],
+        'professional_rut' => request['runProfesional'][0..-2] + '-' +
+          request['runProfesional'][-1],
+        'detail' => request['detalles']}.to_json
     end
     
+    def parse_exam(request)
+      return {}.to_json unless check_request()
+    end
   end
 end

--- a/lib/drivers/centers/medical_center1.rb
+++ b/lib/drivers/centers/medical_center1.rb
@@ -2,33 +2,34 @@ module Drivers
   # Driver for Medical Center 1
   # This parse the request to a normalized json-like hash
   class MedicalCenter1 < BaseDriver
+    def professionals_key_converter(request)
+    { 'speciality' => request['especialidad'],
+      'registration_number' => request['numero_registro'],
+      'registration_date' => request['fecha_registro'],  
+      'rut' => request['run'][0..-2] + '-' + request['run'][-1],
+      'name' => request['nombre'],
+      'last_name' => request['apellido'],
+      'age' => request['edad'],
+      'nationality' => request['nacionalidad'],
+      'phone' => request['telefono']
+    }
+    end
+
     def parse_patients(request)
-      parsed = {}
-      rut_string = request['run']
-      parsed[:rut] = rut_string[0..-2] + '-' + rut_string[-1]
-      parsed[:name], parsed[:last_name] = request['nombre'].split(' ', 2)
-      parsed[:age] = request['edad']
-      parsed
+      nombre = request['nombre'].split(' ', 2)
+      { 'rut' => request['run'][0..-2] + '-' + request['run'][-1],
+        'name' => nombre[0],
+        'last_name' => nombre[1], 
+        'age' => request['edad']}.to_json
     end
 
     def parse_professionals(request)
-      parsed = {}
-      rut_string = request['run']
-      parsed[:rut] = rut_string[0..-2] + '-' + rut_string[-1]
-      parsed[:name] = request['nombre']
-      parsed[:last_name] = request['apellido']
-      parsed[:age] = request['edad']
-      parsed[:nationality] = request['nacionalidad']
-      parsed[:job_title] = request['job_title'] 
-      parsed[:grant_date] = request['grant_date']
-      parsed[:granting_entity] = request['granting_entity']
-      parsed[:speciality] = request['especialidad']
-      parsed[:registration_number] = request['numero_registro']
-      parsed[:registration_date] = request['fecha_registro']
-      parsed[:freelance] = request['freelance']
-      parsed[:email] = request['email']
-      parsed[:phone] = request['telefono']
-      parsed
+      return {}.to_json unless request.empty?
+      request.merge(key_converter(request)).slice!(
+        :especialidad, :numero_registro,
+        :fecha_registro, :run, :nombre,
+        :apellido, :edad, :nacionalidad,
+        :telefono).to_json
     end
 
     def parse_consults(request)

--- a/lib/drivers/centers/medical_center1.rb
+++ b/lib/drivers/centers/medical_center1.rb
@@ -3,6 +3,7 @@ module Drivers
   # This parse the request to a normalized json-like hash
   class MedicalCenter1 < BaseDriver
     def professionals_key_converter(request)
+      return {}.to_json unless request.empty?
     { 'speciality' => request['especialidad'],
       'registration_number' => request['numero_registro'],
       'registration_date' => request['fecha_registro'],  
@@ -16,6 +17,7 @@ module Drivers
     end
 
     def parse_patients(request)
+      return {}.to_json unless request.empty?
       nombre = request['nombre'].split(' ', 2)
       { 'rut' => request['run'][0..-2] + '-' + request['run'][-1],
         'name' => nombre[0],
@@ -33,34 +35,24 @@ module Drivers
     end
 
     def parse_consults(request)
-      parsed = {}
-      rut_string = request['runPaciente']
-      puts rut_string
-      puts request.inspect
-      parsed[:patient_rut] = rut_string[0..-2] + '-' + rut_string[-1]
-      rut_string = request['runProfesional']
-      parsed[:professional_rut] = rut_string[0..-2] + '-' + rut_string[-1]
-      parsed[:date] = request['fecha']
-      parsed[:reason] = request['razon']
-      parsed[:symptoms] = request['sintoma']
-      parsed[:observations] = request['observaciones']
-      parsed
+      return {}.to_json unless request.empty?
+      {
+      'patient_rut' => request['runPaciente'][0..-2] + '-' + request['runPaciente'][-1],
+      'professional_rut' => request['runProfesional'][0..-2] + '-' + request['runProfesional'][-1],
+      'date' => request['fecha'],
+      'reason' => request['razon'],
+      'symptoms' => request['sintoma'],
+      'observations' = request['observaciones']}.to_json
     end
 
     def parse_movements(request)
-      parsed = {}
-      parsed[:type] = request['tipo']
-      rut_string = request['runPaciente']
-      parsed[:patient_rut] = rut_string[0..-2] + '-' + rut_string[-1]
-      rut_string = request['runProfesional']
-      parsed[:professional_rut] = rut_string[0..-2] + '-' + rut_string[-1]
-      parsed[:detail] = request['detalles']
-      parsed
+      return {}.to_json unless request.empty?
+      {
+      'type' => request['tipo'],
+      'patient_rut' => request['runPaciente'][0..-2] + '-' + request['runPaciente'][-1],
+      'professional_rut' => request['runProfesional'][0..-2] + '-' + request['runProfesional'][-1],
+      'detail' =>request['detalles']}.to_json
     end
     
-    def parse_unknown(request)
-      parsed = {}
-      parsed
-    end
   end
 end


### PR DESCRIPTION
Se cambió la estructura por la que pedia Rubocop (Ruby 1.9). Además, se estableció un método de herecia para las partes comunes de un hash (que no cambiaba nada, cosa que así cada metodo tuviera una cosa que hacer). También se buscó la reutilización de memoria y variables, editando el resultado del request para pasarlo como retorno. 

Además se sugiere el cambio de estructura para "detalles" por un objeto JSON, dado que esto mejora la escalabilidad y facilita la definición de los drivers de forma automatizada.

También se pueden enviar archivos.

FALTA:

-->Mayor especificación en los métodos