### PR TITLE
Feature/add token validation to all requests

### DIFF
--- a/app/api/v1/consults.rb
+++ b/app/api/v1/consults.rb
@@ -6,8 +6,8 @@ module V1
     post 'consults' do
       token = headers['Medical-Center-Token']
       request_data = params
-      ActivityLogger.log(type: 'error', message: 'No token provided') unless token
-  
+      unicorn_response = TokenValidation.validate_token(headers)
+      return ActivityLogger.log(type: 'error', message: 'Invalid Token') unless unicorn_response.code == '200'
       request = {
         token: token,
         request_type: 'consults',
@@ -15,10 +15,10 @@ module V1
         queued: nil,
         body: request_data
       }
-  
+
       mongo_connection = MongoConnection.new
       persisted_request = mongo_connection.save_request(request)
-  
+
       DispatcherWorker.perform_async(persisted_request)
     end
   end

--- a/app/api/v1/movements.rb
+++ b/app/api/v1/movements.rb
@@ -6,8 +6,8 @@ module V1
     post 'movements' do
       token = headers['Medical-Center-Token']
       request_data = params
-      ActivityLogger.log(type: 'error', message: 'No token provided') unless token
-  
+      unicorn_response = TokenValidation.validate_token(headers)
+      return ActivityLogger.log(type: 'error', message: 'Invalid Token') unless unicorn_response.code == '200'
       request = {
         token: token,
         request_type: 'movements',
@@ -15,10 +15,10 @@ module V1
         queued: nil,
         body: request_data
       }
-  
+
       mongo_connection = MongoConnection.new
       persisted_request = mongo_connection.save_request(request)
-  
+
       DispatcherWorker.perform_async(persisted_request)
     end
   end

--- a/app/api/v1/professionals.rb
+++ b/app/api/v1/professionals.rb
@@ -6,8 +6,8 @@ module V1
     post 'professionals' do
       token = headers['Medical-Center-Token']
       request_data = params
-      ActivityLogger.log(type: 'error', message: 'No token provided') unless token
-  
+      unicorn_response = TokenValidation.validate_token(headers)
+      return ActivityLogger.log(type: 'error', message: 'Invalid Token') unless unicorn_response.code == '200'
       request = {
         token: token,
         request_type: 'professionals',
@@ -15,10 +15,10 @@ module V1
         queued: nil,
         body: request_data
       }
-  
+
       mongo_connection = MongoConnection.new
       persisted_request = mongo_connection.save_request(request)
-  
+
       DispatcherWorker.perform_async(persisted_request)
     end
   end


### PR DESCRIPTION
# Token Validation to all requests
## Realizado
- Se añade la verificacion en medical_connection del token que envía el centro medico. Sí es valido se almacena en la información en MongoDB y en la BD relacional, si no lo es, registra en MongoDB que el token entregado es invalido. En esta feature fue replicado lo logrado en patients con todos los demas tipos de request.

## ¿Cómo probar?

- Levantar medical_connection y unicorn según las instrucciones en cada proyecto.
- Ejecutar faker para enviar la información.
