### PR TITLE
Movements support ready

### DIFF
--- a/lib/drivers/base_driver.rb
+++ b/lib/drivers/base_driver.rb
@@ -12,17 +12,12 @@ module Drivers
     # Método que deben tener todos los drivers. Permite reciclar JSON de consulta
     def professionals_key_converter(request) end
 
-    def parse_patients(request) end
-
-    def parse_professionals(request) end
-
-    def parse_consults(request) end
-
-    def parse_movements(request)
-      keys = %w[tipo runPaciente runProfesional detalles]
-      request_type = check_movement(request, keys)
-      method_name = "parse_#{request_type}s"
-      public_send(method_name, request)
+    def check_movement(request, attr_required)
+      attr_required.each do |atribute|
+        return 'unknown' unless request.include?(atribute)
+        return 'unknown' if request[atribute].nil?
+      end
+      request['tipo'].downcase!
     end
 
     def parse_unknown(_request)

--- a/lib/drivers/centers/medical_center1.rb
+++ b/lib/drivers/centers/medical_center1.rb
@@ -2,115 +2,74 @@ module Drivers
   # Driver for Medical Center 1
   # This parse the request to a normalized json-like hash
   class MedicalCenter1 < BaseDriver
-
-    def professionals_key_converter(request)  
-      puts request
+    def professionals_key_converter(request)
       return {} if request.empty?
-    { #'speciality' => request['especialidad'],
-      'registration_number' => request['numero_registro'],
-      'registration_date' => request['fecha_registro'],  
-      'rut' => request['run'][0..-2] + '-' + request['run'][-1],
-      'name' => request['nombre'],
-      'last_name' => request['apellido'],
-      'age' => request['edad'],
-      'nationality' => request['nacionalidad'],
-      'phone' => request['telefono'],
-      'speciality_id' =>request['especialidad']
-      #'speciality_id' => 2, #DUMMY SPECIALITY
-    }
+      { 'registration_number' => request['numero_registro'],
+        'registration_date' => request['fecha_registro'],
+        'rut' => request['run'][0..-2] + '-' + request['run'][-1],
+        'name' => request['nombre'],
+        'last_name' => request['apellido'],
+        'age' => request['edad'],
+        'nationality' => request['nacionalidad'],
+        'phone' => request['telefono'],
+        'speciality_id' => request['especialidad'] }
     end
 
     def parse_patients(request)
       return {} unless check_request(request, %w[nombre run edad])
       nombre = request['nombre'].split(' ', 2)
-      a = { 'rut' => request['run'][0..-2] + '-' + request['run'][-1],
+      { 'rut' => request['run'][0..-2] + '-' + request['run'][-1],
         'name' => nombre[0],
-        'last_name' => nombre[1], 
-        'age' => request['edad']}
-      puts a
-      a
+        'last_name' => nombre[1],
+        'age' => request['edad'] }
     end
 
     def parse_professionals(request)
       return {} if request.empty?
-      a = request.merge(professionals_key_converter(request)).slice('id', 'name', 'last_name', 'rut', 'age', 
-        'nationality', 'registration_date', 'freelance', 
-        'job_title', 'grant_date', 'granting_entity', 'email', 'speciality_id', 'registration_number') 
-      puts a
-      a
+      keys = %w[id name last_name rut age nationality registration_date email
+                job_title grant_date granting_entity freelance speciality_id
+                registration_number]
+      request.merge(professionals_key_converter(request)).slice(keys)
     end
 
     def parse_consults(request)
       return {} if request.empty?
-      {
-      'patient_rut' => request['runPaciente'][0..-2] + '-' + request['runPaciente'][-1],
-      'professional_rut' => request['runProfesional'][0..-2] + '-' + request['runProfesional'][-1],
-      'date' => request['fecha'],
-      'reason' => request['razon'],
-      'symptoms' => request['sintoma'],
-      'observations' => request['observaciones']}
+      { 'patient_id' => request['idPaciente'],
+        'professional_id' => request['idProfesional'],
+        'date' => request['fecha'],
+        'reason' => request['razon'],
+        'symptoms' => request['sintoma'],
+        'observations' => request['observaciones'] }
     end
 
     def parse_movements(request)
-      return {} if request.empty?
-      {
-      'type' => request['tipo'],
-      'patient_rut' => request['runPaciente'][0..-2] + '-' + request['runPaciente'][-1],
-      'professional_rut' => request['runProfesional'][0..-2] + '-' + request['runProfesional'][-1],
-      'detail' =>request['detalles']}
+      keys = %w[tipo consulta detalles]
+      return {} if request.empty? || check_movement(request, keys) == 'unknown'
+      { 'type' => request['tipo'],
+        'consult_id' => request['consulta'],
+        'details' => parse_details(request['detalles']) }
     end
 
-    def check_movement(request, attr_required)
-      attr_required.each do |atribute|
-        return 'unknown' unless request.include?(atribute)
-        return 'unknown' if request[atribute].nil?
+    def parse_details(details)
+      return { 'files' => {}, 'details' => {}} if details.nil? || details.empty?
+      { 'files' => get_files(details['files']),
+        'details' => get_details(details['other'])}
+    end
+
+    def get_files(files)
+      return [] if files.nil? || files.empty?
+      parsed_files = []
+      files.each do |file|
+        if file.include?('name') && file.include?('file')
+          parsed_files.push('name' => file['name'], 'content' => file['file'])
+        end
       end
-      request['tipo'].downcase!
+      parsed_files
     end
 
-    def parse_exams(request)
-      {
-        'type' => 'exam',
-        'patient' => request['runPaciente'],
-        'professional' => request['runProfesional'],
-        'details' => request['detalles']
-      }
-    end
-
-    def parse_diagnostics(request)
-      {
-        'type' => 'diagnostic',
-        'patient' => request['runPaciente'],
-        'professional' => request['runProfesional'],
-        'details' => request['detalles']
-      }
-    end
-
-    def parse_prescriptions(request)
-      {
-        'type' => 'prescription',
-        'patient' => request['runPaciente'],
-        'professional' => request['runProfesional'],
-        'details' => request['detalles']
-      }
-    end
-
-    def parse_licenses(request)
-      {
-        'type' => 'license',
-        'patient' => request['runPaciente'],
-        'professional' => request['runProfesional'],
-        'details' => request['detalles']
-      }
-    end
-
-    def parse_procedures(request)
-      {
-        'type' => 'procedures',
-        'patient' => request['runPaciente'],
-        'professional' => request['runProfesional'],
-        'details' => request['detalles']
-      }
+    def get_details(other)
+      return nil unless other.is_a?(String)
+      [{ 'key' => 'demo', 'value' => other }]
     end
   end
 end


### PR DESCRIPTION
Se soporta la conexión y envio de documentos enlazados a una consulta

Se denotan las siguientes advertencias:

-> Dada la falta de un endpoint especifico, se fijó que el id del paciente y profesional para testing será 1
-> El formato de envio del driver está según lo explicitado en el PR #40 de u_project (https://github.com/EtherCorp/u_project/pull/40). Dado que dijo PR está en pruebas, pueden haber fallos prácticos dada que no se ha aceptado aún esos cambios.

Requisitos:
->Creación del centro medico
->Creación del paciente con id 1
->Creación del médico con id 1

Para pruebas, se actualizó el Faker, por tanto el procedimiento de prueba es:

-> Ejecutar [u_project ](https://github.com/EtherCorp/u_project)
-> Ejecutar [u_medical_connection](https://github.com/EtherCorp/u_medical_connection/tree/develop)
-> Ejecutar [u_faker](https://github.com/EtherCorp/u_fake_center/tree/develop)